### PR TITLE
feat: add skipLibCheck: true

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "pretty": true,
     "inlineSourceMap": true,
     "inlineSources": true,
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Motivation
It's extremely common for folks to add `skipLibCheck: true` to tsconfigs. When a library is shipping bogus `.d.ts` files, adding `skipLibCheck: true` is almost always the right move.